### PR TITLE
Do not allow emulator to close our app

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,7 +18,7 @@ BINDIR       = bin
 SOURCES     := $(wildcard $(SRCDIR)/*.$(FILEXT))
 INCLUDES    := $(wildcard $(INCLUDE_PATH)/*.h)
 LIBS        := $(wildcard $(LIB_PATH)/*.h|*.hpp)
-OBJECTS0     := $(SOURCES:$(SRCDIR)/%.$(FILEXT)=$(OBJDIR)/%.o)
+OBJECTS0    := $(SOURCES:$(SRCDIR)/%.$(FILEXT)=$(OBJDIR)/%.o)
 
 LEXSRC      := $(wildcard $(LEXYACC_PATH)/*.l)
 YACCSRC     := $(wildcard $(LEXYACC_PATH)/*.y)

--- a/src/lib.c
+++ b/src/lib.c
@@ -12,6 +12,8 @@
 #include "lib.h"
 
 void _display(const char *restrict fmt, va_list *ap) {
+  // because stderr is unbuffered by default
+  // https://man7.org/linux/man-pages/man3/setbuf.3.html#DESCRIPTION
   vfprintf(stderr, fmt, *ap);
   fprintf(stderr, "\n");
 }


### PR DESCRIPTION
I created a `threadpool` with only one thread and 2 queued job at maximum to prevent children processes to close our app as well as properly checking for errors
```c
#define THREAD 1
#define QUEUE 2
```

also removed a fooking space in the makefile...